### PR TITLE
Changed the format of the default HTTP error count event

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,34 +276,35 @@ Examples are included of how to extend the ```HttpErrorMonitor```, ```HttpErrorC
 
 Your classes can extend these custom monitoring traits and wrap your code with ```monitor``` or ```timer``` as appropriate.
 
-The following shows how to create a custom ```HttpErrorCountMonitor``` with a custom event and custom ```DefaultEventRecorder```.
+The following shows how to create a custom ```Timer``` with a custom event and custom ```DefaultEventRecorder```.
 
 ```scala
-package uk.gov.hmrc.play.events.examples
-
-import uk.gov.hmrc.play.events.DefaultEventRecorder
+import uk.gov.hmrc.play.events._
 import uk.gov.hmrc.play.events.handlers.{DefaultAlertEventHandler, DefaultMetricsEventHandler, EventHandler}
-import uk.gov.hmrc.play.events.Measurable
 import uk.gov.hmrc.play.events.monitoring._
+
+import scala.concurrent.duration.Duration
 
 trait ExampleEventRecorder extends DefaultEventRecorder {
 
   override def eventHandlers: Set[EventHandler] = Set(DefaultMetricsEventHandler, DefaultAlertEventHandler)
 }
 
-trait ExampleHttpErrorCountMonitor extends HttpErrorCountMonitor with ExampleEventRecorder {
+trait ExampleTimer extends Timer with ExampleEventRecorder {
 
   override val source = "TestApp"
 
-  override def createHttpErrorCountEvent(alertCode: AlertCode, failureCode: FailureCode): Measurable = ExampleHttpErrorCountEvent(alertCode: String, failureCode: String)
+  override def createTimerEvent(alertCode: AlertCode, duration: Duration): Measurable = ExampleTimerEvent(alertCode, duration)
 }
 
-case class ExampleHttpErrorCountEvent(alertCode: AlertCode, failureCode: FailureCode) extends Measurable {
+case class ExampleTimerEvent(alertCode: String, duration: Duration) extends Measurable {
 
   override val source = "TestApp"
 
-  override def data: Map[String, String] = Map.empty
+  override def data: Map[String, String] = Map (
+    "Time" -> s"${duration.length}"
+  )
 
-  override def name: String = s"HttpErrorCount-$alertCode-$failureCode"
+  override def name: String = s"Timer-$alertCode"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Auditing, Metrics, Alerts or Logging data can be recorded. A default monitoring 
 ##Download play-events
 
 ```scala
-libraryDependencies += "uk.gov.hmrc" %% "play-events" % "0.7.0"
+resolvers += Resolver.bintrayRepo("hmrc", "releases")
+
+libraryDependencies += "uk.gov.hmrc" %% "play-events" % "x.x.x"
 ```
 
 ##Creating an Alert Event
@@ -308,3 +310,7 @@ case class ExampleTimerEvent(alertCode: String, duration: Duration) extends Meas
   override def name: String = s"Timer-$alertCode"
 }
 ```
+
+##License
+ 
+This code is open source software licensed under the [Apache 2.0 License]("http://www.apache.org/licenses/LICENSE-2.0.html").

--- a/project/HmrcBuild.scala
+++ b/project/HmrcBuild.scala
@@ -31,7 +31,7 @@ object HmrcBuild extends Build {
 private object BuildDependencies {
 
   object Compile {
-    val httpVerbs = "uk.gov.hmrc" %% "http-verbs" % "1.8.0" % "provided"
+    val httpVerbs = "uk.gov.hmrc" %% "http-verbs" % "1.10.0" % "provided"
   }
 
   sealed abstract class Test(scope: String) {

--- a/src/main/scala/uk/gov/hmrc/play/events/monitoring/DefaultHttpErrorCountEvent.scala
+++ b/src/main/scala/uk/gov/hmrc/play/events/monitoring/DefaultHttpErrorCountEvent.scala
@@ -16,7 +16,8 @@
 
 package uk.gov.hmrc.play.events.monitoring
 
-import uk.gov.hmrc.play.events.{Measurable, AlertCode, FailureCode}
+import uk.gov.hmrc.play.events._
+import uk.gov.hmrc.play.http.{HttpException, Upstream5xxResponse, Upstream4xxResponse}
 
 case class DefaultHttpErrorCountEvent(source: String,
                                       name: String,
@@ -24,9 +25,25 @@ case class DefaultHttpErrorCountEvent(source: String,
 
 object DefaultHttpErrorCountEvent {
 
-  def apply(source: String, alertCode: AlertCode, failureCode: FailureCode) = new DefaultHttpErrorCountEvent(
+  def apply(source: String, response: Upstream4xxResponse, alertCode: AlertCode) = new DefaultHttpErrorCountEvent(
     source = source,
-    name = s"HttpErrorCount-$alertCode-$failureCode",
+    name = "Http4xxErrorCount",
+    data = Map (
+      "Count" -> "1"
+    )
+  )
+
+  def apply(source: String, response: Upstream5xxResponse, alertCode: AlertCode) = new DefaultHttpErrorCountEvent(
+    source = source,
+    name = "Http5xxErrorCount",
+    data = Map (
+      "Count" -> "1"
+    )
+  )
+
+  def apply(source: String, exception: HttpException, alertCode: AlertCode) = new DefaultHttpErrorCountEvent(
+    source = source,
+    if (exception.responseCode >= 500) "Http5xxErrorCount" else "Http4xxErrorCount",
     data = Map (
       "Count" -> "1"
     )

--- a/src/main/scala/uk/gov/hmrc/play/events/monitoring/Monitor.scala
+++ b/src/main/scala/uk/gov/hmrc/play/events/monitoring/Monitor.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.play.events.monitoring
 
 import uk.gov.hmrc.play.audit.http.HeaderCarrier
-import uk.gov.hmrc.play.events.{Recordable, Measurable, DefaultEventRecorder, AlertCode, FailureCode, Unknown}
+import uk.gov.hmrc.play.events.{Recordable, Measurable, DefaultEventRecorder, AlertCode, Unknown}
 import uk.gov.hmrc.play.http.{HttpException, Upstream4xxResponse, Upstream5xxResponse}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -33,35 +33,35 @@ trait HttpErrorMonitor extends Monitor {
   override def monitor[T](alertCode: AlertCode = Unknown)(future: Future[T])(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[T] = {
     super.monitor(alertCode) {
       future.andThen {
-        case Failure(exception: Upstream4xxResponse) => record(createHttpEvent(source, exception, alertCode))
-        case Failure(exception: Upstream5xxResponse) => record(createHttpEvent(source, exception, alertCode))
-        case Failure(exception: HttpException) => record(createHttpEvent(source, exception, alertCode))
+        case Failure(exception: Upstream4xxResponse) => record(createHttpErrorEvent(source, exception, alertCode))
+        case Failure(exception: Upstream5xxResponse) => record(createHttpErrorEvent(source, exception, alertCode))
+        case Failure(exception: HttpException) => record(createHttpErrorEvent(source, exception, alertCode))
       }
     }
   }
 
-  protected def createHttpEvent(source: String, response: Upstream4xxResponse, alertCode: AlertCode): Recordable = DefaultHttpErrorEvent(source, response, alertCode)
+  protected def createHttpErrorEvent(source: String, response: Upstream4xxResponse, alertCode: AlertCode): Recordable = DefaultHttpErrorEvent(source, response, alertCode)
 
-  protected def createHttpEvent(source: String, response: Upstream5xxResponse, alertCode: AlertCode): Recordable = DefaultHttpErrorEvent(source, response, alertCode)
+  protected def createHttpErrorEvent(source: String, response: Upstream5xxResponse, alertCode: AlertCode): Recordable = DefaultHttpErrorEvent(source, response, alertCode)
 
-  protected def createHttpEvent(source: String, response: HttpException, alertCode: AlertCode): Recordable = DefaultHttpErrorEvent(source, response, alertCode)
+  protected def createHttpErrorEvent(source: String, response: HttpException, alertCode: AlertCode): Recordable = DefaultHttpErrorEvent(source, response, alertCode)
 }
 
 trait HttpErrorCountMonitor extends Monitor {
 
-  val Failure4xx: FailureCode = "4xx"
-  val Failure5xx: FailureCode = "5xx"
-  val FailureHttp: FailureCode = "Http"
-
   override def monitor[T](alertCode: AlertCode = Unknown)(future: Future[T])(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[T] = {
     super.monitor(alertCode) {
       future.andThen {
-        case Failure(exception: Upstream4xxResponse) => record(createHttpErrorCountEvent(alertCode, Failure4xx))
-        case Failure(exception: Upstream5xxResponse) => record(createHttpErrorCountEvent(alertCode, Failure5xx))
-        case Failure(exception: HttpException) => record(createHttpErrorCountEvent(alertCode, FailureHttp))
+        case Failure(exception: Upstream4xxResponse) => record(createHttpErrorCountEvent(source, exception, alertCode))
+        case Failure(exception: Upstream5xxResponse) => record(createHttpErrorCountEvent(source, exception, alertCode))
+        case Failure(exception: HttpException) => record(createHttpErrorCountEvent(source, exception, alertCode))
       }
     }
   }
 
-  protected def createHttpErrorCountEvent(alertCode: AlertCode, failureCode: FailureCode): Measurable = DefaultHttpErrorCountEvent(source, alertCode, failureCode)
+  protected def createHttpErrorCountEvent(source: String, response: Upstream4xxResponse, alertCode: AlertCode): Measurable = DefaultHttpErrorCountEvent(source, response, alertCode)
+
+  protected def createHttpErrorCountEvent(source: String, response: Upstream5xxResponse, alertCode: AlertCode): Measurable = DefaultHttpErrorCountEvent(source, response, alertCode)
+
+  protected def createHttpErrorCountEvent(source: String, response: HttpException, alertCode: AlertCode): Measurable = DefaultHttpErrorCountEvent(source, response, alertCode)
 }

--- a/src/main/scala/uk/gov/hmrc/play/events/package.scala
+++ b/src/main/scala/uk/gov/hmrc/play/events/package.scala
@@ -19,7 +19,6 @@ package uk.gov.hmrc.play
 package object events {
 
   type AlertCode = String
-  type FailureCode = String
 
   val Unknown: AlertCode = "Unknown"
 }

--- a/src/test/scala/uk/gov/hmrc/play/events/monitoring/AllMonitoringSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/events/monitoring/AllMonitoringSpec.scala
@@ -56,7 +56,7 @@ class AllMonitoringSpec extends WordSpec with MockitoSugar with Matchers {
         )
 
         verify(mockHandler).handle(DefaultHttpErrorEvent(source, response, "test-code"))
-        verify(mockHandler).handle(DefaultHttpErrorCountEvent(source, "test-code", Failure5xx))
+        verify(mockHandler).handle(DefaultHttpErrorCountEvent(source, response, "test-code"))
         verify(mockHandler).handle(isA(classOf[DefaultTimerEvent]))(isA(classOf[HeaderCarrier]))
       }
 

--- a/src/test/scala/uk/gov/hmrc/play/events/monitoring/HttpErrorCountMonitorSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/events/monitoring/HttpErrorCountMonitorSpec.scala
@@ -55,7 +55,7 @@ class HttpErrorCountMonitorSpec extends WordSpec with MockitoSugar with Matchers
           200 millis
         )
 
-        verify(mockHandler).handle(DefaultHttpErrorCountEvent(source, Unknown, Failure4xx))
+        verify(mockHandler).handle(DefaultHttpErrorCountEvent(source, response, Unknown))
       }
     }
 
@@ -79,7 +79,7 @@ class HttpErrorCountMonitorSpec extends WordSpec with MockitoSugar with Matchers
           200 millis
         )
 
-        verify(mockHandler).handle(DefaultHttpErrorCountEvent(source, "test-code", Failure4xx))
+        verify(mockHandler).handle(DefaultHttpErrorCountEvent(source, response, "test-code"))
       }
     }
 
@@ -102,7 +102,7 @@ class HttpErrorCountMonitorSpec extends WordSpec with MockitoSugar with Matchers
           200 millis
         )
 
-        verify(mockHandler).handle(DefaultHttpErrorCountEvent(source, Unknown, Failure5xx))
+        verify(mockHandler).handle(DefaultHttpErrorCountEvent(source, response, Unknown))
       }
 
     }
@@ -126,7 +126,7 @@ class HttpErrorCountMonitorSpec extends WordSpec with MockitoSugar with Matchers
           200 millis
         )
 
-        verify(mockHandler).handle(DefaultHttpErrorCountEvent(source, "test-code", Failure5xx))
+        verify(mockHandler).handle(DefaultHttpErrorCountEvent(source, response, "test-code"))
       }
 
     }
@@ -151,7 +151,7 @@ class HttpErrorCountMonitorSpec extends WordSpec with MockitoSugar with Matchers
           200 millis
         )
 
-        verify(mockHandler).handle(DefaultHttpErrorCountEvent(source, Unknown, Failure4xx))
+        verify(mockHandler).handle(DefaultHttpErrorCountEvent(source, exception4XX, Unknown))
       }
     }
 
@@ -175,7 +175,7 @@ class HttpErrorCountMonitorSpec extends WordSpec with MockitoSugar with Matchers
           200 millis
         )
 
-        verify(mockHandler).handle(DefaultHttpErrorCountEvent(source, "test-code", Failure4xx))
+        verify(mockHandler).handle(DefaultHttpErrorCountEvent(source, exception4XX, "test-code"))
       }
     }
 
@@ -199,7 +199,7 @@ class HttpErrorCountMonitorSpec extends WordSpec with MockitoSugar with Matchers
           200 millis
         )
 
-        verify(mockHandler).handle(DefaultHttpErrorCountEvent(source, Unknown, Failure5xx))
+        verify(mockHandler).handle(DefaultHttpErrorCountEvent(source, exception5XX, Unknown))
       }
     }
 
@@ -223,7 +223,7 @@ class HttpErrorCountMonitorSpec extends WordSpec with MockitoSugar with Matchers
           200 millis
         )
 
-        verify(mockHandler).handle(DefaultHttpErrorCountEvent(source, "test-code", Failure5xx))
+        verify(mockHandler).handle(DefaultHttpErrorCountEvent(source, exception5XX, "test-code"))
       }
     }
 

--- a/src/test/scala/uk/gov/hmrc/play/events/monitoring/StackableMonitoringSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/events/monitoring/StackableMonitoringSpec.scala
@@ -53,7 +53,7 @@ class StackableMonitoringSpec extends WordSpec with MockitoSugar with Matchers {
         )
 
         verify(mockHandler).handle(DefaultHttpErrorEvent(source, response, "test-code"))
-        verify(mockHandler).handle(DefaultHttpErrorCountEvent(source, "test-code", Failure5xx))
+        verify(mockHandler).handle(DefaultHttpErrorCountEvent(source, response, "test-code"))
       }
 
     }


### PR DESCRIPTION
Changed the format of the default HTTP error count event.

Minor changes include adding the license and making the version number generic in the readme file and upgrading to use the latest version of the http-verbs library.